### PR TITLE
more secure API mode forces user to select an authentication method

### DIFF
--- a/data_report/api.php
+++ b/data_report/api.php
@@ -23,6 +23,24 @@ if(!empty($Element['Content']['_APIAuthentication'])) {
 echo dais_customfield('radio', 'Sharedsecret', '_APIAuthentication', '_APIAuthentication', 'list_row2' , 'ss', $Sel, 'Interface accessed with a shared secret.');
 
 echo dais_customfield('text', 'Sharedsecret Seed', '_APISeed', '_APISeed', 'list_row1' , $Element['Content']['_APISeed'], '', 'Seed with random characters to change sharedsecret.');
+
+$Sel = '';
+if(!empty($Element['Content']['_APIAuthentication'])) {
+    if($Element['Content']['_APIAuthentication'] == 'open') {
+        $Sel = 'checked="checked"';
+    }
+}
+echo dais_customfield('radio', 'Open', '_APIAuthentication', '_APIAuthentication', 'list_row2' , 'open', $Sel, 'Public access Interface.');
+
+$Sel = '';
+if(!empty($Element['Content']['_APIAuthentication'])) {
+    if($Element['Content']['_APIAuthentication'] == 'disable') {
+        $Sel = 'checked="checked"';
+    }
+} else if(empty($Element['Content']['_APIAuthentication'])) {
+    $Sel = 'checked="checked"';
+}
+echo dais_customfield('radio', 'Disabled', '_APIAuthentication', '_APIAuthentication', 'list_row2' , 'disable', $Sel, 'Disable API Interface Access.');
 ?>
 <h2>Methods</h2>
 <?php

--- a/libs/api_details.php
+++ b/libs/api_details.php
@@ -1,7 +1,17 @@
-<?php echo get_bloginfo('url').'/ <em><strong>CallName</strong></em> / <em><strong>Key/Token</strong></em> / <em><strong>Method</strong></em> / <em><strong>Format</strong></em> / <em><strong>? GET Variables</strong></em> '; ?>
+<?php 
+if ($Config['_APIAuthentication'] != 'open') {
+    echo get_bloginfo('url').'/ <em><strong>CallName</strong></em> / <em><strong>Key/Token</strong></em> / <em><strong>Method</strong></em> / <em><strong>Format</strong></em> / <em><strong>? GET Variables</strong></em> '; 
+} else {
+    echo get_bloginfo('url').'/ <em><strong>CallName</strong></em> / <em><strong>Method</strong></em> / <em><strong>Format</strong></em> / <em><strong>? GET Variables</strong></em> '; 
+}
+?>
 <h2>API Access Details</h2>
 <?php
-$APIKey = md5($Media['ID']. $Config['_APISeed']);
+if ($Config['_APISeed'] != '') {
+   $APIKey = md5($Media['ID']. $Config['_APISeed']);
+} else {
+   $APIKey = 'Warning: insecure shared secret';
+}
 ?>
 
 <table class="form-table">
@@ -23,19 +33,23 @@ $APIKey = md5($Media['ID']. $Config['_APISeed']);
             </td>
         </tr>
         
+        <?php if ($Config['_APIAuthentication'] != 'open') { ?>
         <tr>
             <th scope="row" span="2">Key</th>
             <td>
                 <?php
                 if($Config['_APIAuthentication'] == 'key'){
                     echo '<div>Your token: '.API_getCurrentUsersKey().'</div>';
-                    echo '<span class="description">This is the token for you. You\'ll need to call the Auth Method as indicated below to retireve the other tokens.</span>';
+                    echo '<span class="description">This is the token for you. You\'ll need to call the Auth Method as indicated below to retrieve the other tokens.</span>';
                 }else{
                     echo $APIKey;
                 }
                 ?>
             </td>
         </tr>
+        <?php } ?>
+
+
         <?php
         if($Config['_APIAuthentication'] == 'key'){
         ?>

--- a/libs/api_engine.php
+++ b/libs/api_engine.php
@@ -19,9 +19,17 @@
     // validate API Key
     $Intrface = get_option($interfaceID);
     $Media = $Intrface;
-    $APIkey = $vars[0];
-    $Method = $vars[1];
-    $Format = $vars[2];
+
+    if (isset($vars[2])) {
+    // secure access interface uses format CallName / Key/Token / Method / Format / ? GET Variables
+        $APIkey = $vars[0];
+        $Method = $vars[1];
+        $Format = $vars[2];
+    } else {
+    // open access interface uses format CallName / Method / Format / ? GET Variables
+        $Method = $vars[0];
+        $Format = $vars[1];
+    }
 
     $Page = 0;
     if(!empty($_GET['offset'])){
@@ -99,7 +107,10 @@
         }
     }
 
-    if($Config['_APIAuthentication'] == 'key'){
+    if (!key_exists('_APIAuthentication', $Config) || $Config['_APIAuthentication'] == 'disable') {
+            api_Deny();
+            exit;
+    } else if($Config['_APIAuthentication'] == 'key'){
         //echo API_getCurrentUsersKey();
         if($userData = API_decodeUsersAPIKey($APIkey)){            
             if($user = get_user_by('id', $userData['id'])){
@@ -117,8 +128,7 @@
             api_Deny();
             exit;
         }
-
-    }else{
+    } else if($Config['_APIAuthentication'] == 'ss'){
         $VerifyKey = md5($interfaceID.$Config['_APISeed']);
         if ($VerifyKey !== $APIkey) {
             api_Deny();


### PR DESCRIPTION
Original version does not select a default value for  '_APIAuthentication'. The original version operates as if a shared secret key of empty string was chosen.  This set of changes defaults to a 'disable' choice for '_APIAuthentication' and warns if the shared secret is set to empty string.  An additional no-authentication method is also introduced as well, which while not very secure, at least the option is available.

FYI, I did not unit-test for "API key" mode.  I didn't have a test case handy.  This reminds me, unit testing would definitely be valuable. There are many combinations of features that can interfere with each other as demonstrated by yesterday's patch.
