### PR TITLE
Set sql_quote_show_create off for picky dbDelta()

### DIFF
--- a/dbtoolkit_import.php
+++ b/dbtoolkit_import.php
@@ -164,12 +164,15 @@ if(!empty($_FILES['itfInstaller']['size'])){
                 // Upload Logo
 
                 $newFileName = uniqid('dbtlgo').'.png';
-                $logoFile = wp_upload_bits($newFileName, null, base64_decode($data['Logo']));
-                if(!empty($logoFile)){
-                    $data['AppSettings']['imageURL'] = $logoFile['url'];
-                    $data['AppSettings']['imageFile'] = $logoFile['file'];
-                }
+
+                if (isset($data['Logo'])) {
+                    $logoFile = wp_upload_bits($newFileName, null, base64_decode($data['Logo']));
+                    if(!empty($logoFile)){
+                        $data['AppSettings']['imageURL'] = $logoFile['url'];
+                        $data['AppSettings']['imageFile'] = $logoFile['file'];
+                    }
                 unset($data['Logo']);
+                }
 
                 // Create Tables
                 global $wpdb;

--- a/libs/functions.php
+++ b/libs/functions.php
@@ -2495,6 +2495,10 @@ function exportApp($app, $publish=false){
 
         // Export Table Structures and Data
         if(!empty($tables)){
+            $quote_show_create = $wpdb->get_row("SHOW VARIABLES LIKE 'sql_quote_show_create';");
+            if ($quote_show_create->Value === "ON")
+               $wpdb->query("SET sql_quote_show_create=OFF;");
+
             $output['Data'] = array();
             foreach($tables as $tableKey=>$table){
                 $tableCreates = $wpdb->get_row("SHOW CREATE TABLE ".$table, ARRAY_N);
@@ -2511,6 +2515,8 @@ function exportApp($app, $publish=false){
                     $output['Data'][] = base64_encode("INSERT INTO `".$tableKey."` (".implode(',', $Fields).") VALUES (".implode(',', $Values).");");
                 }
             }
+            if ($quote_show_create->Value === "ON")
+               $wpdb->query("SET sql_quote_show_create=ON;");
         }
 
 


### PR DESCRIPTION
dbDelta() is fussy; this pull request inhibits quotes when calling "SHOW TABLE CREATE" during an application export to prevent future application imports from tripping over problems of dbDelta() implementation.

Wordpress codex says dbDelta()'s constraints are..
You must put each field on its own line in your SQL statement.

You must have two spaces between the words PRIMARY KEY and the definition of your primary key.

You must use the key word KEY rather than its synonym INDEX and you must include at least one KEY.

You must not use any apostrophes or backticks around field names.
