### PR TITLE
Fix for autocomplete feature for linked fields. Test on WP 3.5.1

### DIFF
--- a/data_form/fieldtypes/linked/functions.php
+++ b/data_form/fieldtypes/linked/functions.php
@@ -688,7 +688,8 @@ function linked_autocomplete($eid, $Field, $query){
 
 	$Element = getelement($eid);
 	$Config = $Element['Content'];	
-	$Setup = $Config[$Table];
+	// David Holloway - do not understand this line $Setup = $Config[$Table];
+	// $Setup = $Config[$Table];
 	$Table = $Config['_Linkedfields'][$Field]['Table'];
 	$ID = $Config['_Linkedfields'][$Field]['ID'];
 	$Wheres = '';

--- a/data_form/fieldtypes/linked/input.php
+++ b/data_form/fieldtypes/linked/input.php
@@ -174,7 +174,7 @@ if($FieldSet[1] == 'linked'){
 
                         // get the linked interfaces add entry button title
                         if(!empty($Config['_Linkedfields'][$Field]['_addInterface'])){
-                        $linkInterface = getelement($Config['_Linkedfields'][$Field]['_addInterface']);                        
+                        $linkInterface = getelement($Config['_Linkedfields'][$Field]['_addInterface']);
                             $Return .= ' <button class="btn" onclick="df_buildQuickCaptureForm(\''.$Config['_Linkedfields'][$Field]['_addInterface'].'\', true, \''.$Element['ID'].'|'.$Field.'\', linked_reloadField);return false;">'.$linkInterface['Content']['_New_Item_Title'].'</button>';
                         }
                         $_SESSION['dataform']['OutScripts'] .="
@@ -215,8 +215,6 @@ if($FieldSet[1] == 'linked'){
 				//$Return .= ob_get_clean();
 				$VisDef = $OutString;
 			}
-			//$FieldID = uniqid('check_'.$Field);
-			//$Return .= '<input type="text" id="autocomplete_'.$FieldID.'" class="textfield" value="'.$Det[$IDField].' ['.$Det[$ValueField].']" /><input type="hidden" name="dataForm['.$ElementID.']['.$Field.']" id="autocomplete_'.$FieldID.'_value" value="'.$Det[$IDField].'" class="'.$Req.'" />';
 			$Return .= '<input type="text" id="entry_'.$Element['ID'].'_'.$Field.'_view" class="'.$Req.' '.$Config['_FormFieldWidth'][$Field].'" value="'.$VisDef.'" autocomplete="off" /><input type="hidden" name="dataForm['.$Element['ID'].']['.$Field.']" id="entry_'.$Element['ID'].'_'.$Field.'" value="'.$Det[$Config['_Linkedfields'][$Field]['ID']].'" />';
 
 
@@ -241,6 +239,20 @@ if($FieldSet[1] == 'linked'){
                                         jQuery( this ).removeClass( \"ui-corner-top\" ).addClass( \"ui-corner-all\" );
                                 }
                         });
+
+                        // enable autocomplete
+                        jQuery('#entry_".$Element['ID']."_".$Field."_view').each( function(index, element) {
+							$(element).attr('autocomplete', 'on');
+                        });
+
+                        ";
+
+                        // get the linked interfaces add entry button title
+                        if(!empty($Config['_Linkedfields'][$Field]['_addInterface'])){
+                        $linkInterface = getelement($Config['_Linkedfields'][$Field]['_addInterface']);                        
+                            $Return .= ' <button class="btn" onclick="df_buildQuickCaptureForm(\''.$Config['_Linkedfields'][$Field]['_addInterface'].'\', true, \''.$Element['ID'].'|'.$Field.'\', linked_reloadField);return false;">'.$linkInterface['Content']['_New_Item_Title'].'</button>';
+                        }
+                        $_SESSION['dataform']['OutScripts'] .="
                         ";
 
                         /*

--- a/libs/functions.php
+++ b/libs/functions.php
@@ -505,6 +505,7 @@ function dt_scripts($preIs = false) {
         wp_enqueue_script("jquery-ui-sortable");
         wp_enqueue_script("jquery-ui-tabs");
         wp_enqueue_script('jquery-multiselect');
+        wp_enqueue_script('jquery-ui-autocomplete');
         wp_enqueue_script('data_report');
         wp_enqueue_script('data_form');
         wp_enqueue_script('jquery-validate');


### PR DESCRIPTION
I am excited to say I fixed the autocomplete feature.
The key change is with setting attribute autocomplete "on".
By default, jqueryUI leaves new elements disabled until later enabled.

 +                        // enable autocomplete
 +                        jQuery('#entry_".$Element['ID']."_".$Field."_view').each( function(index, element) {
 +              $(element).attr('autocomplete', 'on');
 +                        });

